### PR TITLE
feat: allow admin demo login

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -13,16 +13,16 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Search, Filter, Download } from "lucide-react";
 
-interface Column {
-  key: string;
+interface Column<T = Record<string, unknown>> {
+  key: keyof T & string;
   label: string;
-  render?: (value: any, item: any) => ReactNode;
+  render?: (value: T[keyof T], item: T) => ReactNode;
 }
 
-interface DataTableProps {
+interface DataTableProps<T = Record<string, unknown>> {
   title: string;
-  columns: Column[];
-  data: any[];
+  columns: Column<T>[];
+  data: T[];
   loading?: boolean;
   filters?: {
     search?: string;
@@ -36,20 +36,20 @@ interface DataTableProps {
   };
   actions?: {
     onCreate?: () => void;
-    onView?: (item: any) => void;
-    onEdit?: (item: any) => void;
-    onDelete?: (item: any) => void;
+    onView?: (item: T) => void;
+    onEdit?: (item: T) => void;
+    onDelete?: (item: T) => void;
   };
 }
 
-export function DataTable({ 
-  title, 
-  columns, 
-  data, 
-  loading = false, 
+export function DataTable<T = Record<string, unknown>>({
+  title,
+  columns,
+  data,
+  loading = false,
   filters,
-  actions 
-}: DataTableProps) {
+  actions
+}: DataTableProps<T>) {
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('es-AR', {
       style: 'currency',

--- a/src/components/common/ExcelUploader.tsx
+++ b/src/components/common/ExcelUploader.tsx
@@ -69,11 +69,11 @@ export default function ExcelUploader({ onDataProcessed, onClose }: ExcelUploade
   };
 
   // Función para validar una fila de datos
-  const validateRow = (row: any, rowIndex: number): { data: ExcelData | null; errors: ValidationError[] } => {
+  const validateRow = (row: Record<string, unknown>, rowIndex: number): { data: ExcelData | null; errors: ValidationError[] } => {
     const errors: ValidationError[] = [];
     
     // Validar fecha
-    const fecha = row['Fecha (YYYY-MM-DD)'];
+    const fecha = row['Fecha (YYYY-MM-DD)'] as string;
     if (!fecha) {
       errors.push({ fila: rowIndex, campo: 'Fecha', error: 'Campo requerido' });
     } else if (!/^\d{4}-\d{2}-\d{2}$/.test(fecha)) {
@@ -81,13 +81,13 @@ export default function ExcelUploader({ onDataProcessed, onClose }: ExcelUploade
     }
 
     // Validar detalle
-    const detalle = row['Detalle'];
+    const detalle = row['Detalle'] as string;
     if (!detalle || detalle.trim().length === 0) {
       errors.push({ fila: rowIndex, campo: 'Detalle', error: 'Campo requerido' });
     }
 
     // Validar monto
-    const monto = parseFloat(row['Monto Asignado']);
+    const monto = parseFloat(row['Monto Asignado'] as string);
     if (!monto || isNaN(monto) || monto <= 0) {
       errors.push({ fila: rowIndex, campo: 'Monto Asignado', error: 'Debe ser un número mayor a 0' });
     }
@@ -95,7 +95,8 @@ export default function ExcelUploader({ onDataProcessed, onClose }: ExcelUploade
     // Validar campos de clasificación presupuestaria
     const camposRequeridos = ['Tarea', 'Objetivo', 'Proyecto', 'Actividad', 'Programa', 'Inciso'];
     camposRequeridos.forEach(campo => {
-      if (!row[campo] || row[campo].trim().length === 0) {
+      const valor = row[campo] as string | undefined;
+      if (!valor || valor.trim().length === 0) {
         errors.push({ fila: rowIndex, campo, error: 'Campo requerido' });
       }
     });
@@ -136,7 +137,7 @@ export default function ExcelUploader({ onDataProcessed, onClose }: ExcelUploade
         const sheet = workbook.Sheets[sheetName];
         
         // Convertir a JSON
-        const jsonData = XLSX.utils.sheet_to_json(sheet);
+        const jsonData = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet);
 
         if (jsonData.length === 0) {
           toast({

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,16 +1,14 @@
 import { NavLink, useLocation } from "react-router-dom";
 import { mockAuthState } from "@/data/mockData";
-import { 
-  Building2, 
-  Calculator, 
-  CreditCard, 
-  BarChart3, 
-  FileText, 
-  Receipt, 
-  Banknote,
+import {
+  Calculator,
+  CreditCard,
+  BarChart3,
+  FileText,
+  Receipt,
   Shield,
   ChevronDown,
-  Menu
+  type LucideIcon
 } from "lucide-react";
 import {
   Sidebar,
@@ -27,7 +25,14 @@ import {
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useState } from "react";
 
-const menuItems = [
+interface MenuItem {
+  title: string;
+  icon: LucideIcon;
+  url?: string;
+  items?: MenuItem[];
+}
+
+const menuItems: MenuItem[] = [
   {
     title: "Presupuesto",
     icon: Calculator,
@@ -74,9 +79,8 @@ export function AppSidebar() {
   const isViewer = currentUser?.role === 'VIEWER';
 
   const isActive = (path: string) => location.pathname === path;
-  const isGroupActive = (items: any[]) => items.some(item => 
-    item.url ? isActive(item.url) : item.items?.some((subItem: any) => isActive(subItem.url))
-  );
+  const isGroupActive = (items: MenuItem[]) =>
+    items.some(item => (item.url ? isActive(item.url) : item.items?.some(subItem => isActive(subItem.url ?? ""))));
 
   const toggleGroup = (groupTitle: string) => {
     setOpenGroups(prev => 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -3,8 +3,17 @@ import { User, AsignacionCredito, PedidoCuota, Compromiso, Devengado, Pago, Soli
 // Usuarios mock
 export const mockUsers: User[] = [
   {
+    id: '0',
+    username: 'admin',
+    password: 'admin',
+    role: 'ADMIN',
+    safId: 'SAF-000',
+    safName: 'SAF'
+  },
+  {
     id: '1',
     username: 'admin.saf1',
+    password: '123456',
     role: 'ADMIN',
     safId: 'SAF-001',
     safName: 'SAF'
@@ -12,6 +21,7 @@ export const mockUsers: User[] = [
   {
     id: '2',
     username: 'user.saf2',
+    password: '123456',
     role: 'USER',
     safId: 'SAF-002',
     safName: 'SAF'
@@ -19,6 +29,7 @@ export const mockUsers: User[] = [
   {
     id: '3',
     username: 'viewer.panel',
+    password: '123456',
     role: 'VIEWER',
     safId: 'SAF-000',
     safName: 'SAF'

--- a/src/pages/ControlPanel.tsx
+++ b/src/pages/ControlPanel.tsx
@@ -244,8 +244,8 @@ export default function ControlPanel() {
                     tickFormatter={(value) => `$${(value / 1000000).toFixed(1)}M`}
                   />
                   {/* Tooltip que aparece al hacer hover */}
-                  <Tooltip 
-                    formatter={(value: any) => [`$${(value / 1000000).toFixed(2)}M`, 'Ejecutado']}
+                  <Tooltip
+                    formatter={(value: number) => [`$${(value / 1000000).toFixed(2)}M`, 'Ejecutado']}
                     labelStyle={{ color: 'hsl(var(--foreground))' }}
                     contentStyle={{ 
                       backgroundColor: 'hsl(var(--background))', 
@@ -295,8 +295,8 @@ export default function ControlPanel() {
                     ))}
                   </Pie>
                   {/* Tooltip personalizado */}
-                  <Tooltip 
-                    formatter={(value: any) => [`$${(value / 1000000).toFixed(2)}M`, 'Monto']}
+                  <Tooltip
+                    formatter={(value: number) => [`$${(value / 1000000).toFixed(2)}M`, 'Monto']}
                     contentStyle={{ 
                       backgroundColor: 'hsl(var(--background))', 
                       border: '1px solid hsl(var(--border))',
@@ -337,8 +337,8 @@ export default function ControlPanel() {
                     tickFormatter={(value) => `$${(value / 1000000).toFixed(1)}M`}
                   />
                   {/* Tooltip */}
-                  <Tooltip 
-                    formatter={(value: any) => [`$${(value / 1000000).toFixed(2)}M`, '']}
+                  <Tooltip
+                    formatter={(value: number) => [`$${(value / 1000000).toFixed(2)}M`, '']}
                     labelStyle={{ color: 'hsl(var(--foreground))' }}
                     contentStyle={{ 
                       backgroundColor: 'hsl(var(--background))', 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -26,9 +26,9 @@ export default function Login() {
 
     // Simulamos una autenticación
     setTimeout(() => {
-      const user = mockUsers.find(u => u.username === username);
-      
-      if (user && password === "123456") {
+      const user = mockUsers.find(u => u.username === username && u.password === password);
+
+      if (user) {
         mockAuthState.isAuthenticated = true;
         mockAuthState.currentUser = user;
         
@@ -132,6 +132,7 @@ export default function Login() {
           <div className="mt-6 p-4 bg-muted/50 rounded-lg text-xs text-muted-foreground">
             <p className="font-semibold mb-2">Usuarios de prueba:</p>
             <div className="space-y-1">
+              <p><strong>admin</strong> / admin (Administrador)</p>
               <p><strong>admin.saf1</strong> / 123456 (Administrador)</p>
               <p><strong>user.saf2</strong> / 123456 (Usuario)</p>
               <p><strong>viewer.panel</strong> / 123456 (Solo Panel)</p>

--- a/src/pages/ejecucion/CompromisosList.tsx
+++ b/src/pages/ejecucion/CompromisosList.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataTable } from "@/components/common/DataTable";
 import { mockCompromisos, mockPedidos } from "@/data/mockData";
-import { FilterState } from "@/types";
+import { FilterState, type Compromiso } from "@/types";
 import { useToast } from "@/hooks/use-toast";
 
 export default function CompromisosList() {
@@ -48,21 +48,21 @@ export default function CompromisosList() {
     navigate('/app/ejecucion/compromisos/nuevo');
   };
 
-  const handleView = (compromiso: any) => {
+  const handleView = (compromiso: Compromiso) => {
     toast({
       title: "Ver Compromiso",
       description: `Visualizando detalles de ${compromiso.id}`,
     });
   };
 
-  const handleEdit = (compromiso: any) => {
+  const handleEdit = (compromiso: Compromiso) => {
     toast({
       title: "Editar Compromiso",
       description: `Editando ${compromiso.id}`,
     });
   };
 
-  const handleDelete = (compromiso: any) => {
+  const handleDelete = (compromiso: Compromiso) => {
     toast({
       variant: "destructive",
       title: "Eliminar Compromiso",

--- a/src/pages/ejecucion/DevengadosList.tsx
+++ b/src/pages/ejecucion/DevengadosList.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataTable } from "@/components/common/DataTable";
 import { mockDevengados, mockCompromisos } from "@/data/mockData";
-import { FilterState } from "@/types";
+import { FilterState, type Devengado } from "@/types";
 import { useToast } from "@/hooks/use-toast";
 
 export default function DevengadosList() {
@@ -48,21 +48,21 @@ export default function DevengadosList() {
     navigate('/app/ejecucion/devengados/nuevo');
   };
 
-  const handleView = (devengado: any) => {
+  const handleView = (devengado: Devengado) => {
     toast({
       title: "Ver Devengado",
       description: `Visualizando detalles de ${devengado.id}`,
     });
   };
 
-  const handleEdit = (devengado: any) => {
+  const handleEdit = (devengado: Devengado) => {
     toast({
       title: "Editar Devengado",
       description: `Editando ${devengado.id}`,
     });
   };
 
-  const handleDelete = (devengado: any) => {
+  const handleDelete = (devengado: Devengado) => {
     toast({
       variant: "destructive",
       title: "Eliminar Devengado",

--- a/src/pages/ejecucion/PagosList.tsx
+++ b/src/pages/ejecucion/PagosList.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataTable } from "@/components/common/DataTable";
 import { mockPagos, mockDevengados } from "@/data/mockData";
-import { FilterState } from "@/types";
+import { FilterState, type Pago } from "@/types";
 import { useToast } from "@/hooks/use-toast";
 
 export default function PagosList() {
@@ -60,21 +60,21 @@ export default function PagosList() {
     navigate('/app/ejecucion/pagos/nuevo');
   };
 
-  const handleView = (pago: any) => {
+  const handleView = (pago: Pago) => {
     toast({
       title: "Ver Pago",
       description: `Visualizando detalles de ${pago.id}`,
     });
   };
 
-  const handleEdit = (pago: any) => {
+  const handleEdit = (pago: Pago) => {
     toast({
       title: "Editar Pago",
       description: `Editando ${pago.id}`,
     });
   };
 
-  const handleDelete = (pago: any) => {
+  const handleDelete = (pago: Pago) => {
     toast({
       variant: "destructive",
       title: "Eliminar Pago",

--- a/src/pages/presupuesto/AsignacionForm.tsx
+++ b/src/pages/presupuesto/AsignacionForm.tsx
@@ -66,7 +66,7 @@ export default function AsignacionForm() {
   };
 
   // Función para procesar datos del Excel
-  const handleExcelDataProcessed = async (excelData: any[]) => {
+  const handleExcelDataProcessed = async (excelData: Record<string, unknown>[]) => {
     setLoading(true);
 
     // Simulamos el procesamiento masivo en el backend

--- a/src/pages/presupuesto/AsignacionesList.tsx
+++ b/src/pages/presupuesto/AsignacionesList.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataTable } from "@/components/common/DataTable";
 import { mockAsignaciones } from "@/data/mockData";
-import { FilterState } from "@/types";
+import { FilterState, type AsignacionCredito } from "@/types";
 import { useToast } from "@/hooks/use-toast";
 
 export default function AsignacionesList() {
@@ -42,7 +42,7 @@ export default function AsignacionesList() {
     navigate('/app/presupuesto/asignaciones/nueva');
   };
 
-  const handleView = (asignacion: any) => {
+  const handleView = (asignacion: AsignacionCredito) => {
     toast({
       title: "Ver Asignación",
       description: `Visualizando detalles de ${asignacion.id}`,
@@ -50,7 +50,7 @@ export default function AsignacionesList() {
     // En una implementación real, navegaría a la vista de detalle
   };
 
-  const handleEdit = (asignacion: any) => {
+  const handleEdit = (asignacion: AsignacionCredito) => {
     toast({
       title: "Editar Asignación",
       description: `Editando ${asignacion.id}`,
@@ -58,7 +58,7 @@ export default function AsignacionesList() {
     // En una implementación real, navegaría al formulario de edición
   };
 
-  const handleDelete = (asignacion: any) => {
+  const handleDelete = (asignacion: AsignacionCredito) => {
     toast({
       variant: "destructive",
       title: "Eliminar Asignación",

--- a/src/pages/presupuesto/PedidosList.tsx
+++ b/src/pages/presupuesto/PedidosList.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataTable } from "@/components/common/DataTable";
 import { mockPedidos, mockAsignaciones } from "@/data/mockData";
-import { FilterState } from "@/types";
+import { FilterState, type PedidoCuota } from "@/types";
 import { useToast } from "@/hooks/use-toast";
 
 export default function PedidosList() {
@@ -48,21 +48,21 @@ export default function PedidosList() {
     navigate('/app/presupuesto/pedidos/nuevo');
   };
 
-  const handleView = (pedido: any) => {
+  const handleView = (pedido: PedidoCuota) => {
     toast({
       title: "Ver Pedido",
       description: `Visualizando detalles de ${pedido.id}`,
     });
   };
 
-  const handleEdit = (pedido: any) => {
+  const handleEdit = (pedido: PedidoCuota) => {
     toast({
       title: "Editar Pedido",
       description: `Editando ${pedido.id}`,
     });
   };
 
-  const handleDelete = (pedido: any) => {
+  const handleDelete = (pedido: PedidoCuota) => {
     toast({
       variant: "destructive",
       title: "Eliminar Pedido",

--- a/src/pages/presupuesto/SolicitudList.tsx
+++ b/src/pages/presupuesto/SolicitudList.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { DataTable } from "@/components/common/DataTable";
 import { mockSolicitudes, mockAsignaciones } from "@/data/mockData";
-import { FilterState } from "@/types";
+import { FilterState, type SolicitudPresupuestaria } from "@/types";
 import { useToast } from "@/hooks/use-toast";
 
 export default function SolicitudList() {
@@ -62,21 +62,21 @@ export default function SolicitudList() {
     navigate('/app/presupuesto/solicitudes/nueva');
   };
 
-  const handleView = (solicitud: any) => {
+  const handleView = (solicitud: SolicitudPresupuestaria) => {
     toast({
       title: "Ver Solicitud",
       description: `Visualizando detalles de ${solicitud.id}`,
     });
   };
 
-  const handleEdit = (solicitud: any) => {
+  const handleEdit = (solicitud: SolicitudPresupuestaria) => {
     toast({
       title: "Editar Solicitud",
       description: `Editando ${solicitud.id}`,
     });
   };
 
-  const handleDelete = (solicitud: any) => {
+  const handleDelete = (solicitud: SolicitudPresupuestaria) => {
     toast({
       variant: "destructive",
       title: "Eliminar Solicitud",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@
 export interface User {
   id: string;
   username: string;
+  password: string;
   role: 'ADMIN' | 'USER' | 'VIEWER';
   safId: string;
   safName: string;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -115,5 +116,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add password field to user type and mock data, including admin/admin credentials
- validate login against stored passwords and list the new admin account in sample users

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955ecf7e44832ea6c8999b75a93863